### PR TITLE
Info when no API key is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,8 +98,9 @@ async fn main() {
         return;
     }
 
+    let config = &mut utils::get_config();
+
     if args.contains(&"--api-key".to_owned()) {
-        let config = &mut utils::get_config();
         let pos = args.iter().position(|s| s == "--api-key").unwrap();
         if pos + 1 >= args.len() {
             let api_key = config.get_api_key();
@@ -116,10 +117,12 @@ async fn main() {
 
         println!("{}", "API key set".green());
         return;
+    } else if config.get_api_key().is_empty() {
+        println!("{}", "No API key set. Set API key first!".yellow());
+        return;
     }
 
     if args.contains(&"--clear-api-key".to_owned()) {
-        let config = &mut utils::get_config();
         config.set_api_key("".to_owned());
         config.save();
 


### PR DESCRIPTION
When the user had no api key set and tries to run the program *(exept flags like `--help`, `--version` are set)*, it will exit after letting the user know that it is not set.

Before this the user gets an error, like
`Error: Error: invalid type: map, expected a string at line 2 column 13`